### PR TITLE
fix: don't escape password chars

### DIFF
--- a/extension/authenticator.mustache.js
+++ b/extension/authenticator.mustache.js
@@ -6,10 +6,12 @@ let maxRetries = 3; // todo: configurable?
     /**
      * @param details - see https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onAuthRequired#details
      */
+
+    // don't escape password chars when rendering (since symbols are expected and must be preserved)
     function authenticator(details) {
         return (--maxRetries < 0)
             ? { cancel: true }
-            : { authCredentials: { username: `{{ username }}`, password: `{{ password }}` }};
+            : { authCredentials: { username: `{{ username }}`, password: `{{{ password }}}` }};
     },
     { urls: [ '<all_urls>' ]},
     [ 'blocking' ],


### PR DESCRIPTION
don't escape password chars when rendering (since symbols are expected in passwords and must be preserved)